### PR TITLE
Support multiple Draw.io diagrams on the same page

### DIFF
--- a/includes/FD_DisplayDiagram.php
+++ b/includes/FD_DisplayDiagram.php
@@ -37,8 +37,7 @@ class FDDisplayDiagram {
 			return '<div class="error">' . "Page [[$diagramPage]] does not exist." . '</div>';
 		}
 
-		if ( $diagramPage->getNamespace() == FD_NS_BPMN || $diagramPage->getNamespace() == FD_NS_GANTT
-		|| $diagramPage->getNamespace() == FD_NS_DRAWIO ) {
+		if ( $diagramPage->getNamespace() == FD_NS_BPMN || $diagramPage->getNamespace() == FD_NS_GANTT ) {
 			if ( self::$numInstances++ > 0 ) {
 				return '<div class="error">Due to current limitations, #display_diagram can only ' .
 					'be called once per page on any BPMN or Gantt diagram.</div>';
@@ -63,8 +62,8 @@ class FDDisplayDiagram {
 			global $wgOut;
 			$wgOut->addModules( 'ext.flexdiagrams.drawio' );
 			$text = Html::element( 'div', [
-				'id' => 'canvas',
-				'data-wiki-page' => $diagramPageName
+				'data-mw-flexdiagrams-type' => 'drawio',
+				'data-mw-flexdiagrams-page' => $diagramPageName
 			], ' ' );
 		} elseif ( $diagramPage->getNamespace() == FD_NS_DOT ) {
 			global $wgOut, $wgResourceLoaderDebug;

--- a/includes/FD_DrawioContent.php
+++ b/includes/FD_DrawioContent.php
@@ -16,7 +16,7 @@ class FDDrawioContent extends TextContent {
 
 		$wgOut->addModules( 'ext.flexdiagrams.drawio' );
 		$text = Html::element( 'div', [
-			'id' => 'canvas',
+			'data-mw-flexdiagrams-type' => 'drawio',
 		], '' );
 		$text .= Html::element( 'pre', [], $this->mText );
 		return $text;

--- a/includes/FD_SpecialEditDiagram.php
+++ b/includes/FD_SpecialEditDiagram.php
@@ -46,7 +46,7 @@ class FDSpecialEditDiagram extends UnlistedSpecialPage {
 			$text = '<div id="canvas"></div>' . "\n";
 		} elseif ( $title->getNamespace() == FD_NS_DRAWIO ) {
 			$out->addModules( 'ext.flexdiagrams.drawio' );
-			$text = '<div id="canvas"></div>' . "\n";
+			$text = '<div data-mw-flexdiagrams-type="drawio"></div>' . "\n";
 
 		} elseif ( $title->getNamespace() == FD_NS_MERMAID ) {
 			global $wgResourceLoaderDebug;


### PR DESCRIPTION
- Use data attributes instead of ID as selector to avoid conflicts with other elements
- Prepend data attribute with  so that values can't be injected through wikitext

<img width="998" height="538" alt="image" src="https://github.com/user-attachments/assets/736a8e2f-2b0b-4175-bea0-36bd16f90f26" />


Note:
- `feat-drawio` serves as a temporary branch to hold our additions for drawio, until the changes is merged upstream.
- Filed upstream patch: https://gerrit.wikimedia.org/r/c/mediawiki/extensions/FlexDiagrams/+/1194308