### PR TITLE
Allow Draw.io editor to go fullscreen

### DIFF
--- a/extension.json
+++ b/extension.json
@@ -176,17 +176,22 @@
 		},
 		"ext.flexdiagrams.drawio": {
 			"scripts": [
+				"resources/FD_editor.js",
 				"resources/ext.flexdiagrams.drawio.js"
 			],
 			"styles": [
+				"resources/FD_editor.less",
 				"resources/FD_Drawio.css"
 			],
 			"dependencies": [
 				"ext.flexdiagrams",
-				"oojs-ui-widgets"
+				"oojs-ui-widgets",
+				"oojs-ui.styles.icons-media"
 			],
 			"messages": [
-				"flexdiagrams-drawio-saveinfo"
+				"flexdiagrams-drawio-saveinfo",
+				"flexdiagrams-editor-fullscreen",
+				"flexdiagrams-editor-exit-fullscreen"
 			]
 		},
 		"ext.flexdiagrams.dot": {

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -19,5 +19,7 @@
 	"flexdiagrams-gantt-days": "Days",
 	"flexdiagrams-gantt-weeks": "Weeks",
 	"flexdiagrams-gantt-months": "Months",
-	"flexdiagrams-gantt-years": "Years"
+	"flexdiagrams-gantt-years": "Years",
+	"flexdiagrams-editor-fullscreen": "Enter fullscreen",
+	"flexdiagrams-editor-exit-fullscreen": "Exit fullscreen"
 }

--- a/i18n/qqq.json
+++ b/i18n/qqq.json
@@ -22,5 +22,7 @@
 	"flexdiagrams-gantt-days": "An option for a timeline zoom level",
 	"flexdiagrams-gantt-weeks": "An option for a timeline zoom level",
 	"flexdiagrams-gantt-months": "An option for a timeline zoom level\n{{identical|Month}}",
-	"flexdiagrams-gantt-years": "An option for a timeline zoom level"
+	"flexdiagrams-gantt-years": "An option for a timeline zoom level",
+	"flexdiagrams-editor-fullscreen": "Enter fullscreen",
+	"flexdiagrams-editor-exit-fullscreen": "Exit fullscreen"
 }

--- a/includes/FD_SpecialEditDiagram.php
+++ b/includes/FD_SpecialEditDiagram.php
@@ -46,7 +46,10 @@ class FDSpecialEditDiagram extends UnlistedSpecialPage {
 			$text = '<div id="canvas"></div>' . "\n";
 		} elseif ( $title->getNamespace() == FD_NS_DRAWIO ) {
 			$out->addModules( 'ext.flexdiagrams.drawio' );
-			$text = '<div data-mw-flexdiagrams-type="drawio"></div>' . "\n";
+			$text = Html::element( 'div', [
+				'id' => 'ext-flexdiagrams-editor',
+				'data-mw-flexdiagrams-type' => 'drawio'
+			], ' ' );
 
 		} elseif ( $title->getNamespace() == FD_NS_MERMAID ) {
 			global $wgResourceLoaderDebug;

--- a/resources/FD_editor.js
+++ b/resources/FD_editor.js
@@ -1,0 +1,144 @@
+/**
+ * Shared editor functionality for FlexDiagrams
+ * Provides common features like fullscreen toggle for all editors
+ */
+( function ( $, mw, fd ) {
+
+	'use strict';
+
+	fd.editor = fd.editor || {};
+
+	const FULLSCREEN_LABEL = mw.msg( 'flexdiagrams-editor-fullscreen' );
+	const EXIT_FULLSCREEN_LABEL = mw.msg( 'flexdiagrams-editor-exit-fullscreen' );
+
+	let listenerAttached = false;
+	let fullscreenButtonWidget;
+
+	/**
+	 * Toggles fullscreen mode for a container element.
+	 *
+	 * @param {string} containerId - The ID of the container element.
+	 * @return {void}
+	 */
+	function toggleFullscreen( containerId ) {
+		const container = document.getElementById( containerId );
+		if ( !container ) {
+			return;
+		}
+
+		if ( !document.fullscreenElement ) {
+			// Enter fullscreen
+			if ( container.requestFullscreen ) {
+				container.requestFullscreen();
+			} else if ( container.webkitRequestFullscreen ) {
+				container.webkitRequestFullscreen();
+			} else if ( container.msRequestFullscreen ) {
+				container.msRequestFullscreen();
+			}
+		} else {
+			// Exit fullscreen
+			if ( document.exitFullscreen ) {
+				document.exitFullscreen();
+			} else if ( document.webkitExitFullscreen ) {
+				document.webkitExitFullscreen();
+			} else if ( document.msExitFullscreen ) {
+				document.msExitFullscreen();
+			}
+		}
+	}
+
+	/**
+	 * Creates a fullscreen toggle button.
+	 *
+	 * @param {string} containerId - The ID of the container element to make fullscreen.
+	 * @return {jQuery} The fullscreen button element.
+	 */
+	function createFullscreenButton( containerId ) {
+		fullscreenButtonWidget = new OO.ui.ButtonWidget( {
+			icon: 'fullScreen',
+			title: FULLSCREEN_LABEL,
+			classes: [ 'ext-flexdiagrams-editor-fullscreen-button' ]
+		} );
+
+		fullscreenButtonWidget.on( 'click', () => {
+			toggleFullscreen( containerId );
+		} );
+
+		return fullscreenButtonWidget.$element;
+	}
+
+	/**
+	 * Sets up a listener for fullscreen change events to update the button.
+	 *
+	 * @return {void}
+	 */
+	function setupFullscreenListener() {
+		if ( listenerAttached ) {
+			return;
+		}
+		document.addEventListener( 'fullscreenchange', () => {
+			if ( fullscreenButtonWidget ) {
+				if ( document.fullscreenElement ) {
+					fullscreenButtonWidget.setIcon( 'exitFullscreen' );
+					fullscreenButtonWidget.setTitle( EXIT_FULLSCREEN_LABEL );
+				} else {
+					fullscreenButtonWidget.setIcon( 'fullScreen' );
+					fullscreenButtonWidget.setTitle( FULLSCREEN_LABEL );
+				}
+			}
+		} );
+		listenerAttached = true;
+	}
+
+	/**
+	 * Creates an editor container with an iframe and optional fullscreen button.
+	 *
+	 * @param {jQuery} $container - The container element.
+	 * @param {Object} options - Configuration options.
+	 * @param {string} options.src - Source URL for the iframe.
+	 * @param {boolean} options.allowFullscreen - Whether to enable fullscreen functionality.
+	 * @return {jQuery} The created iframe element.
+	 */
+	fd.editor.createEditor = function ( $container, options = {} ) {
+		const defaults = {
+			src: '',
+			allowFullscreen: false
+		};
+
+		const config = Object.assign( {}, defaults, options );
+
+		const containerId = $container.attr( 'id' );
+
+		if ( config.allowFullscreen && !containerId ) {
+			// eslint-disable-next-line no-console
+			console.error( 'FlexDiagrams: The container for a fullscreen editor must have an ID.' );
+		}
+
+		$container.css( {
+			position: 'relative',
+			margin: '-10px', // Counteract the margin added by the container
+			height: '80vh'
+		} );
+
+		const $iframe = $( '<iframe>' )
+			.attr( 'id', 'ext-flexdiagram-editor-iframe' )
+			.attr( 'src', config.src )
+			.attr( 'frameborder', '0' )
+			.css( {
+				width: '100%',
+				height: '100%'
+			} );
+
+		if ( config.allowFullscreen ) {
+			$iframe.attr( 'allow', 'fullscreen' );
+			const $fullscreenBtn = createFullscreenButton( containerId );
+			$container.append( $fullscreenBtn );
+			setupFullscreenListener();
+		}
+
+		$container.append( $iframe );
+
+		return $iframe;
+	};
+
+}( jQuery, mediaWiki, flexdiagrams ) );

--- a/resources/FD_editor.less
+++ b/resources/FD_editor.less
@@ -1,0 +1,22 @@
+.ext-flexdiagrams-editor {
+	&-fullscreen-button {
+		position: absolute;
+		top: 8px;
+		right: 8px;
+
+		&.oo-ui-buttonWidget {
+			margin-right: 0; // Remove the default margin added by OOUI
+
+			> .oo-ui-buttonElement-button {
+				/**
+				 * OOUI framed buttons have weird default widths and heights,
+				 * so we set them to 32px to match the icon size.
+				 * These styles are only applied to the fullscreen button.
+				 */
+				width: 32px;
+				height: 32px;
+				padding: 0;
+			}
+		}
+	}
+}

--- a/resources/ext.flexdiagrams.drawio.js
+++ b/resources/ext.flexdiagrams.drawio.js
@@ -24,8 +24,10 @@
 	const editor = 'https://embed.diagrams.net/?embed=1&spin=1&proto=json';
 
 	function edit( path, content, $container ) {
-		const $iframe = $( '<iframe>' );
-		$iframe.attr( 'frameborder', '0' );
+		const $iframe = fd.editor.createEditor( $container, {
+			src: editor,
+			allowFullscreen: true
+		} );
 
 		const pageName = $container.attr( 'data-mw-flexdiagrams-page' ) || mw.config.get( 'wgPageName' );
 
@@ -95,8 +97,6 @@
 		};
 
 		window.addEventListener( 'message', receive );
-		$iframe.attr( 'src', editor );
-		$container.append( $iframe );
 	}
 
 	fd.drawio.prototype = drawio_proto;


### PR DESCRIPTION
Added a fullscreen overlay button for toggling the Draw.io editor into fullscreen. The implementation is generic and reusable so that it can be applied to other editors.

https://github.com/user-attachments/assets/9b2f9551-c08b-40a0-b8ed-e728ea90fe43

Upstream patch: https://gerrit.wikimedia.org/r/c/mediawiki/extensions/FlexDiagrams/+/1194335

