### PR TITLE
Mark diagram pages as transclusion for display_diagram parser function

### DIFF
--- a/extension.json
+++ b/extension.json
@@ -259,5 +259,8 @@
 			"description": "Whether to render Drawio diagrams directly as <svg> elements instead of <img> elements."
 		}
 	},
+	"ConfigRegistry": {
+		"flexdiagrams": "GlobalVarConfig::newInstance"
+	},
 	"manifest_version": 2
 }


### PR DESCRIPTION
Since diagram pages are technically transcluded into the page, it is helpful to mark them as transclusion to populate the Special:WhatLinksHere list on the diagram page.

Minor cleanups and refactor to the `FDDisplayDiagram` for maintainability:
- Re-use various variables when possible
- Use switch instead of if-else for diagram type logic
- Use ParserOutput instead of wgOut to add RL modules
- Drop unnessecary Parser cache invalidation logic
- Set up config instance
- Break down run method into smaller methods

<img width="1101" height="620" alt="image" src="https://github.com/user-attachments/assets/ed13d6da-7240-434c-8282-08e11c26d0e1" />

Upstream: https://gerrit.wikimedia.org/r/c/mediawiki/extensions/FlexDiagrams/+/1197703